### PR TITLE
Refactor download_bookmarks, lower min delay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__/
 # Ignore app.log file
 app.log
 
+# Ignore the Downloaded Works folder
+Downloaded Works/

--- a/main.py
+++ b/main.py
@@ -40,8 +40,8 @@ def main():
 
                 if action == "download":
                     chosen_format = user_input.get_download_format(logger)
-                    downloading_utils.download_bookmarks(url, start_page, end_page, session, chosen_format, delay,
-                                                         logger)
+                    downloading_utils.download_bookmarks(username, logged_in, start_page, end_page, session,
+                                                         chosen_format, delay, logger)
                 elif action == "scrape":
                     scraping_utils.scrape_bookmarks(username, start_page, end_page, session, delay, logger)
 

--- a/utils/user_input.py
+++ b/utils/user_input.py
@@ -212,9 +212,10 @@ def get_page_range(session, url, logger):
 def get_delay(logger):
     while True:
         try:
-            delay = int(input("\nEnter an interval delay between requests. Should be at least 5 seconds: "))
-            if delay < 5:
-                error_handling.handle_invalid_input("Please enter a delay of at least 5 seconds.", logger)
+            delay = int(input("\nEnter the interval delay between requests (at least 1 second, suggested value "
+                              "is 5 seconds): "))
+            if delay < 1:
+                error_handling.handle_invalid_input("Please enter a delay of at least 1 second.", logger)
                 continue
             break
 


### PR DESCRIPTION
- Added a delay for each downloaded work, regardless of whether it was skipped or not.
- Resolved an issue that caused the script to incorrectly initiate downloading from the first page of bookmarks for logged-in users, regardless of the specified input.
- Reduced the minimum delay to 1 second
- Updated .gitignore